### PR TITLE
Add descriptor handling hook

### DIFF
--- a/examples/bulkloop/bulkloop.c
+++ b/examples/bulkloop/bulkloop.c
@@ -135,6 +135,10 @@ void main() {
 
 // copied routines from setupdat.h
 
+BOOL handle_get_descriptor() {
+  return FALSE;
+}
+
 // value (low byte) = ep
 #define VC_EPSTAT 0xB1
 

--- a/examples/eeprom/firmware/eeprom.c
+++ b/examples/eeprom/firmware/eeprom.c
@@ -74,6 +74,9 @@ void main() {
 
 }
 
+BOOL handle_get_descriptor() {
+  return FALSE;
+}
 
 #define VC_EEPROM 0xb1
         

--- a/fw/device.c
+++ b/fw/device.c
@@ -24,6 +24,10 @@
 #define printf(...)
 #endif
 
+BOOL handle_get_descriptor() {
+
+}
+
 //************************** Configuration Handlers *****************************
 
 // change to support as many interfaces as you need

--- a/lib/setupdat.c
+++ b/lib/setupdat.c
@@ -31,6 +31,7 @@
 #include <setupdat.h>
 
 
+extern BOOL handle_get_descriptor();
 extern BOOL handle_vendorcommand(BYTE cmd);
 extern BOOL handle_set_configuration(BYTE cfg);
 extern BOOL handle_get_interface(BYTE ifc, BYTE* alt_ifc);
@@ -54,7 +55,7 @@ BOOL handle_set_feature();
   // 0x04 is reserved
 //  SET_ADDRESS=0x05, // this is handled by EZ-USB core unless RENUM=0
 //  GET_DESCRIPTOR,
-void handle_get_descriptor();
+void _handle_get_descriptor();
 //  SET_DESCRIPTOR,
 //  GET_CONFIGURATION, // handled by callback
 //  SET_CONFIGURATION, // handled by callback
@@ -89,7 +90,8 @@ void handle_setupdata() {
             }
             break;
         case GET_DESCRIPTOR:
-            handle_get_descriptor();
+            if (!handle_get_descriptor())
+              _handle_get_descriptor();
             break;
         case GET_CONFIGURATION:            
             EP0BUF[0] = handle_get_configuration();
@@ -301,7 +303,7 @@ void handle_hispeed(BOOL highspeed) {
  *  String
  *  Other-Speed
  **/
-void handle_get_descriptor() {
+void _handle_get_descriptor() {
     //printf ( "Get Descriptor\n" );
     
     switch ( SETUPDAT[3] ) {


### PR DESCRIPTION
Simple hook to allow user handling of descriptor requests (to support HID, etc). This allows, for example, fw/fw.c to do something like:

``` c
void handle_get_descriptor() {
  switch ( SETUPDAT[3] ) {
    case DSCR_HID: //HID Descriptor
      SUDPTRH = MSB((WORD)&hid_dscr);
      SUDPTRL = LSB((WORD)&hid_dscr);
      return TRUE;
    case DSCR_HID_REPORT: //Report Descriptor
      //...
      return TRUE;
  }
  //did not handle the request
  return FALSE;
}
```
