### PR TITLE
eputils: NAKALL must be kept asserted until last fifo is reset.

### DIFF
--- a/include/eputils.h
+++ b/include/eputils.h
@@ -55,16 +55,16 @@
  * Only use 0x02, 0x04, 0x06, 0x06 for ep value
  **/
 #define RESETFIFO(ep) {FIFORESET=0x80; SYNCDELAY;\
-                       FIFORESET=ep; SYNCDELAY;\
+                       FIFORESET=0x80 | ep; SYNCDELAY;\
                        FIFORESET=0x00; SYNCDELAY;}
 /**
  * Quickly reset all endpoint FIFOS.
  **/
 #define RESETFIFOS() {FIFORESET=0x80; SYNCDELAY;\
-                     FIFORESET=0x02; SYNCDELAY;\
-                     FIFORESET=0x04; SYNCDELAY;\
-                     FIFORESET=0x06; SYNCDELAY;\
-                     FIFORESET=0x08; SYNCDELAY;\
+                     FIFORESET=0x82; SYNCDELAY;\
+                     FIFORESET=0x84; SYNCDELAY;\
+                     FIFORESET=0x86; SYNCDELAY;\
+                     FIFORESET=0x88; SYNCDELAY;\
                      FIFORESET=0x00; SYNCDELAY;}
 
 /**


### PR DESCRIPTION
As specified in
  EZ-USB® Technical Reference Manual, Document # 001-13670 Rev. *D
(and since rev. *A), table C-1 page 384:
  Set flags and byte counts to default
  values; write 0x80 to NAK all trans-
  fers, then write NAKALL OR’ed with
  FIFO number, then write 0x00 to re-
  store normal operation