### PR TITLE
Clean target fix

### DIFF
--- a/lib/fx2.mk
+++ b/lib/fx2.mk
@@ -97,7 +97,7 @@ load: $(BUILDDIR)/$(BASENAME).bix
 	fx2load -v $(VID) -p $(PID) $(BUILDDIR)/$(BASENAME).bix
 
 clean:
-	rm -f $(foreach ext, asm ihx lnk lst map mem rel rest sym adb cdb bix, $(BUILDDIR)/*.${ext})
+	rm -f $(foreach ext, a51 asm ihx lnk lk lst map mem rel rst rest sym adb cdb bix, $(BUILDDIR)/*.${ext})
 
 clean-all: clean
 	$(MAKE) -C $(FX2LIBDIR)/lib clean

--- a/lib/fx2.mk
+++ b/lib/fx2.mk
@@ -97,7 +97,7 @@ load: $(BUILDDIR)/$(BASENAME).bix
 	fx2load -v $(VID) -p $(PID) $(BUILDDIR)/$(BASENAME).bix
 
 clean:
-	rm -f $(BUILDDIR)/*.{asm,ihx,lnk,lst,map,mem,rel,rst,sym,adb,cdb,bix}
+	rm -f $(foreach ext, asm ihx lnk lst map mem rel rest sym adb cdb bix, $(BUILDDIR)/*.${ext})
 
 clean-all: clean
 	$(MAKE) -C $(FX2LIBDIR)/lib clean


### PR DESCRIPTION
Make clean target fix to make it works with plain /bin/sh
Otherwise clean leaves files not removed on my Ubuntu box, due to makefile using bash extensions.