### PR TITLE
serial: Extend baud rate argument to DWORD to allow all rates.

### DIFF
--- a/include/serial.h
+++ b/include/serial.h
@@ -45,7 +45,7 @@
  *    most hardware specs for working.  All rates at 48mhz work at .16%
  **/
 
-void sio0_init( WORD baud_rate ) __critical ; // baud_rate max should be 57600 since int=2 bytes
+void sio0_init( DWORD baud_rate ) __critical ; // baud_rate max should be 57600 since int=2 bytes
 
 /**
  putchar('\\n') or putchar('\\r') both transmit \\r\\n

--- a/lib/serial.c
+++ b/lib/serial.c
@@ -26,7 +26,7 @@
  * using the comp port implies that timer 2 will be used as
  * a baud rate generator.  (Don't use timer 2)
  **/
-void sio0_init( WORD baud_rate ) __critical { // baud_rate max should be 57600 since int=2 bytes
+void sio0_init( DWORD baud_rate ) __critical { // baud_rate max should be 57600 since int=2 bytes
 	
     WORD hl; // hl value for reload	
 	BYTE mult; // multiplier for clock speed


### PR DESCRIPTION
This patch comes from https://github.com/sschnelle/fx2lib/commit/e1aaafdf416fbc43de76a8f5e37a75b87372ebd6 but has been rebased onto your latest master.