### PR TITLE
Adding DSCR_DEBUG_TYPE definition.

### DIFF
--- a/include/setupdat.h
+++ b/include/setupdat.h
@@ -175,6 +175,7 @@ void handle_hispeed( BOOL highspeed );
 #define DSCR_STRING_TYPE 3
 #define DSCR_DEVQUAL_TYPE 6
 #define DSCR_OTHERSPD_TYPE 7
+#define DSCR_DEBUG_TYPE 10
 
 /* usb spec 2 */
 #define DSCR_BCD 2


### PR DESCRIPTION
The debug type descriptor is a Linux extension to the descriptor types which is useful for debugging problems in the USB stack. It is used by the usbmon and debugdevice firmware.