### PR TITLE
Couple of small fixes

### DIFF
--- a/fw/fw.c
+++ b/fw/fw.c
@@ -29,8 +29,7 @@
 #define printf(...)
 #endif
 
-
-
+#define SUSPEND_ENABLED
 
 volatile __bit dosud=FALSE;
 volatile __bit dosuspend=FALSE;
@@ -78,6 +77,7 @@ void main() {
        handle_setupdata();
      }
 
+#ifdef SUSPEND_ENABLED
      if (dosuspend) {
         dosuspend=FALSE;
         do {
@@ -107,7 +107,7 @@ void main() {
         }
 
      }
-
+#endif
  } // end while
 
 } // end main

--- a/lib/setupdat.c
+++ b/lib/setupdat.c
@@ -309,7 +309,10 @@ void handle_hispeed(BOOL highspeed) {
  **/
 void _handle_get_descriptor() {
     //printf ( "Get Descriptor\n" );
-    
+
+    // Sets to "Setup Data Pointer Auto Mode" see Appendix C - 29 of TRM
+    SUDPTRCTL = 0x01;
+
     switch ( SETUPDAT[3] ) {
         case DSCR_DEVICE_TYPE:
             printf ( "Get Device Config\n" );


### PR DESCRIPTION
A couple of small fixes from other people.

 * The makestuff patch allows disabling the suspend code.
 * The SUDPTRCTL patch is the important one. Without that patch if any part of the firmware disables the auto pointer code, the firmware will stop functioning.