### PR TITLE
WIP: Code and documentation around USART and I2C interrupts

### DIFF
--- a/include/fx2ints.h
+++ b/include/fx2ints.h
@@ -55,24 +55,61 @@ typedef enum {
  IE4_ISR, ///< External interrupt 4.  An interrupt handler for this should only be used if not using auto vectored interrupts with int4
  IE5_ISR, ///< External interrupt 5
  IE6_ISR, ///< External interrupt 6
+ // Better names for the USART ISR names
+ USART0_ISR = TI_0_ISR,
+ USART1_ISR = TI_1_ISR,
 } FX2_ISR;
 
+/**
+ * \brief Interrupt high priority.
+ **/
+#define INTERRUPT_HIGH_PRIO	1
+/**
+ * \brief Interrupt low priority.
+ **/
+#define INTERRUPT_LOW_PRIO	0
+
+
+// TIMER0
+// =======================================================================
 
 /**
  * \brief Enable the timer 0 interrupt.
  *
- * There is not CLEAR_TIMER0 because the timer interrupt flag 
- * is automatically cleared when the isr is called.
+ * CLEAR_TIMER0() is a NOP because the timer interrupt flag is automatically
+ * cleared when the ISR is called.
  **/
 #define ENABLE_TIMER0() ET0=1
 
 /**
+ *  \brief Clear timer 0 interrupt
+ *
+ * CLEAR_TIMER0() is a NOP because the timer interrupt flag is automatically
+ * cleared when the ISR is called.
+ **/
+#define CLEAR_TIMER0()
+
+// TIMER1
+// =======================================================================
+
+/**
  * \brief Enable timer 1 interrupt
- * There is no CLEAR_TIMER1 because the timer interrupt flag
- * is automatically cleared when the isr is called.
+ *
+ * CLEAR_TIMER1() is a NOP because the timer interrupt flag is automatically
+ * cleared when the ISR is called.
  **/
 #define ENABLE_TIMER1() ET1=1
 
+/**
+ *  \brief Clear timer 1 interrupt
+ *
+ * CLEAR_TIMER1() is a NOP because the timer interrupt flag is automatically
+ * cleared when the ISR is called.
+ **/
+#define CLEAR_TIMER1()
+
+// TIMER2 and external EXF2 interrupt
+// =======================================================================
 
 /**
  * \brief Enable timer 2 interrupt
@@ -88,6 +125,12 @@ typedef enum {
  **/
 #define CLEAR_TIMER2() TF2=0;EXF2=0;
 
+// Resume interrupt
+// =======================================================================
+// After the FX2 has entered its idle state, it responds to an external signal
+// on its WAKEUP/WU2 pins or resumption of USB bus activity by restarting its
+// oscillator and resuming firmware execution.
+
 /**
  * \brief Enable the Resume Interrupt.  Requires EA=1 separately.
  **/
@@ -99,18 +142,132 @@ typedef enum {
  **/
 #define CLEAR_RESUME() RESI=0
 
+// Interrupt 4 - Autovectored FIFO / GPIF or External interrupt 4
+// =======================================================================
 
-#define ENABLE_INT4() 
+//#define ENABLE_INT4()
+
+// External Interrupt 5
+// =======================================================================
 
 /**
  * \brief 
- * Enable external interupt for int5#
+ * Enable external interrupt for INT5#
  **/
 #define ENABLE_INT5() EIEX5=1 
 
 /**
  * \brief 
- * Clear int5# interrupt
+ * Clear INT5# interrupt
  **/
-#define CLEAR_INT5() EXIF &= ~0x80
+#define CLEAR_INT5() \
+	EXIF &= ~bmIE5
 
+// USART0
+// =======================================================================
+
+/**
+ * \brief Set the USART 0 interrupt priority.
+ *
+ * Does *not* enable the interrupt.
+ *
+ * SET_USART0_ISR_PRIO(INTERRUPT_HIGH_PRIO) -- Set USART0 to high priority
+ * SET_USART0_ISR_PRIO(INTERRUPT_LOW_PRIO)  -- Set USART0 to low priority
+ **/
+#define SET_USART0_ISR_PRIORITY(p) \
+	PS0 = p
+/**
+ * \brief Enable the USART 0 interrupt.
+ *
+ * Requires enabling global interrupts (EA=1) separately.
+ *
+ * The USART interrupt fires for both *receive* (RX) and *transmit* (TX)
+ * completing, the interrupt must clear *both*.
+ **/
+#define ENABLE_USART0() \
+	ES0 = 1;
+/**
+ *  \brief Clear USART 0 RX bit.
+ **/
+#define CLEAR_USART0_RX() \
+	RI = 0;
+/**
+ *  \brief Clear USART 0 TX bit.
+ **/
+#define CLEAR_USART0_TX() \
+	TI = 0;
+/**
+ *  \brief Clear USART 0 both TX & RX bit.
+ **/
+#define CLEAR_USART0() \
+	CLEAR_USART0_RX(); \
+	CLEAR_USART0_TX();
+
+// USART1
+// =======================================================================
+
+/**
+ * \brief Set the USART 1 interrupt priority.
+ *
+ * Does *not* enable the interrupt.
+ *
+ * SET_USART1_ISR_PRIO(INTERRUPT_HIGH_PRIO) -- Set USART1 to high priority
+ * SET_USART1_ISR_PRIO(INTERRUPT_LOW_PRIO)  -- Set USART1 to low priority
+ **/
+#define SET_USART1_ISR_PRIORITY(p) \
+	PS1 = p
+/**
+ * \brief Enable the USART 1 interrupt.
+ *
+ * Requires enabling global interrupts (EA=1) separately.
+ *
+ * The USART interrupt fires for both *receive* (RX) and *transmit* (TX)
+ * completing, the interrupt must clear *both*.
+ **/
+#define ENABLE_USART1() \
+	ES1 = 1;
+/**
+ *  \brief Clear USART 1 receive (RI1) bit.
+ **/
+#define CLEAR_USART1_RX() \
+	RI1 = 0;
+/**
+ *  \brief Clear USART 1 transmit (TI1) bit.
+ **/
+#define CLEAR_USART1_TX() \
+	TI1 = 0;
+/**
+ *  \brief Clear USART 1 both TX & RX bits.
+ **/
+#define CLEAR_USART1() \
+	CLEAR_USART1_RX(); \
+	CLEAR_USART1_TX();
+
+// I2C Interrupt
+// =======================================================================
+
+/**
+ * \brief Set the I2C interrupt priority.
+ *
+ * Does *not* enable the interrupt.
+ *
+ * SET_I2C_ISR_PRIO(INTERRUPT_HIGH_PRIO) -- Set I2C to high priority
+ * SET_I2C_ISR_PRIO(INTERRUPT_LOW_PRIO)  -- Set I2C to low priority
+ **/
+#define SET_I2C_ISR_PRIORITY(p) \
+	PI2C = p
+/**
+ * \brief Enable the I2C interrupt.
+ *
+ * Requires enabling global interrupts (EA=1) separately.
+ *
+ * The USART interrupt fires for both *receive* (RX) and *transmit* (TX)
+ * completing, the interrupt must clear *both*.
+ **/
+#define ENABLE_I2C() \
+	EI2C = 1;
+/**
+ *  \brief Clear I2C interrupt.
+ **/
+#define CLEAR_I2C() \
+	EXIF &= ~bmI2CINT;

--- a/include/fx2ints.h
+++ b/include/fx2ints.h
@@ -39,7 +39,6 @@
 
 /**
  * \brief Interrupt numbers for standard FX2 interrupts.
-
  **/
 typedef enum {
  IE0_ISR=0, ///< External interrupt 0
@@ -55,9 +54,9 @@ typedef enum {
  IE4_ISR, ///< External interrupt 4.  An interrupt handler for this should only be used if not using auto vectored interrupts with INT4
  IE5_ISR, ///< External interrupt 5
  IE6_ISR, ///< External interrupt 6
- // Better names for the USART ISR names
- USART0_ISR = TI_0_ISR,
- USART1_ISR = TI_1_ISR,
+ // Better names for the USART interrupts
+ USART0_ISR = TI_0_ISR, ///< Better name for USART0 interrupt
+ USART1_ISR = TI_1_ISR, ///< Better name for USART1 interrupt
 } FX2_ISR;
 
 /**
@@ -82,7 +81,7 @@ typedef enum {
 #define ENABLE_TIMER0() ET0=1
 
 /**
- *  \brief Clear timer 0 interrupt
+ * \brief Clear timer 0 interrupt
  *
  * CLEAR_TIMER0() is a NOP because the timer interrupt flag is automatically
  * cleared when the ISR is called.
@@ -101,7 +100,7 @@ typedef enum {
 #define ENABLE_TIMER1() ET1=1
 
 /**
- *  \brief Clear timer 1 interrupt
+ * \brief Clear timer 1 interrupt
  *
  * CLEAR_TIMER1() is a NOP because the timer interrupt flag is automatically
  * cleared when the ISR is called.
@@ -119,9 +118,9 @@ typedef enum {
  **/
 #define ENABLE_TIMER2() ET2=1
 /**
- *  \brief Clear timer 2 interrupt
+ * \brief Clear timer 2 interrupt
  *
- *  Clears both the TF2 AND EXF2 flag
+ * Clears both the TF2 AND EXF2 flag
  **/
 #define CLEAR_TIMER2() TF2=0;EXF2=0;
 
@@ -171,8 +170,10 @@ typedef enum {
  *
  * Does *not* enable the interrupt.
  *
- * SET_USART0_ISR_PRIO(INTERRUPT_HIGH_PRIO) -- Set USART0 to high priority
- * SET_USART0_ISR_PRIO(INTERRUPT_LOW_PRIO)  -- Set USART0 to low priority
+ * \code
+ *  SET_USART0_ISR_PRIO(INTERRUPT_HIGH_PRIO); // Set USART0 to high priority
+ *  SET_USART0_ISR_PRIO(INTERRUPT_LOW_PRIO);  // Set USART0 to low priority
+ * \endcode
  **/
 #define SET_USART0_ISR_PRIORITY(p) \
 	PS0 = p
@@ -187,17 +188,17 @@ typedef enum {
 #define ENABLE_USART0() \
 	ES0 = 1;
 /**
- *  \brief Clear USART 0 RX bit.
+ * \brief Clear USART 0 RX bit.
  **/
 #define CLEAR_USART0_RX() \
 	RI = 0;
 /**
- *  \brief Clear USART 0 TX bit.
+ * \brief Clear USART 0 TX bit.
  **/
 #define CLEAR_USART0_TX() \
 	TI = 0;
 /**
- *  \brief Clear USART 0 both TX & RX bit.
+ * \brief Clear USART 0 both TX & RX bit.
  **/
 #define CLEAR_USART0() \
 	CLEAR_USART0_RX(); \
@@ -211,8 +212,10 @@ typedef enum {
  *
  * Does *not* enable the interrupt.
  *
- * SET_USART1_ISR_PRIO(INTERRUPT_HIGH_PRIO) -- Set USART1 to high priority
- * SET_USART1_ISR_PRIO(INTERRUPT_LOW_PRIO)  -- Set USART1 to low priority
+ * \code
+ * SET_USART1_ISR_PRIO(INTERRUPT_HIGH_PRIO); // Set USART1 to high priority
+ * SET_USART1_ISR_PRIO(INTERRUPT_LOW_PRIO);  // Set USART1 to low priority
+ * \endcode
  **/
 #define SET_USART1_ISR_PRIORITY(p) \
 	PS1 = p
@@ -227,17 +230,17 @@ typedef enum {
 #define ENABLE_USART1() \
 	ES1 = 1;
 /**
- *  \brief Clear USART 1 receive (RI1) bit.
+ * \brief Clear USART 1 receive (RI1) bit.
  **/
 #define CLEAR_USART1_RX() \
 	RI1 = 0;
 /**
- *  \brief Clear USART 1 transmit (TI1) bit.
+ * \brief Clear USART 1 transmit (TI1) bit.
  **/
 #define CLEAR_USART1_TX() \
 	TI1 = 0;
 /**
- *  \brief Clear USART 1 both TX & RX bits.
+ * \brief Clear USART 1 both TX & RX bits.
  **/
 #define CLEAR_USART1() \
 	CLEAR_USART1_RX(); \
@@ -251,8 +254,10 @@ typedef enum {
  *
  * Does *not* enable the interrupt.
  *
- * SET_I2C_ISR_PRIO(INTERRUPT_HIGH_PRIO) -- Set I2C to high priority
- * SET_I2C_ISR_PRIO(INTERRUPT_LOW_PRIO)  -- Set I2C to low priority
+ * \code
+ *  SET_I2C_ISR_PRIO(INTERRUPT_HIGH_PRIO) // Set I2C to high priority
+ *  SET_I2C_ISR_PRIO(INTERRUPT_LOW_PRIO)  // Set I2C to low priority
+ * \endcode
  **/
 #define SET_I2C_ISR_PRIORITY(p) \
 	PI2C = p
@@ -267,7 +272,7 @@ typedef enum {
 #define ENABLE_I2C() \
 	EI2C = 1;
 /**
- *  \brief Clear I2C interrupt.
+ * \brief Clear I2C interrupt.
  **/
 #define CLEAR_I2C() \
 	EXIF &= ~bmI2CINT;

--- a/include/fx2ints.h
+++ b/include/fx2ints.h
@@ -15,7 +15,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 /*! \file 
- *  Define the standard fx2 interrupts.  For int2 and int4 autovector
+ *  Define the standard FX2 interrupts.  For INT2 and INT4 autovector
  *  interrupts see \ref autovector.h
  *
  *  To enable an interrupt, simply define an interrupt handler function
@@ -38,7 +38,7 @@
 
 
 /**
- * \brief interrupt numbers for standard fx2 interrupts
+ * \brief Interrupt numbers for standard FX2 interrupts.
 
  **/
 typedef enum {
@@ -50,9 +50,9 @@ typedef enum {
  TF2_ISR, ///< Timer 2 interrupt
  RESUME_ISR, ///< Resume interrupt
  TI_1_ISR, ///< Serial port 1 transmit or receive interrupt
- USBINT_ISR, ///< Usb Interrupt.  An interrupt handler for this should only be used if not using auto vectored interrupts with int2
+ USBINT_ISR, ///< USB Interrupt.  An interrupt handler for this should only be used if not using auto vectored interrupts with INT2
  I2CINT_ISR, ///< I2C Bus interrupt
- IE4_ISR, ///< External interrupt 4.  An interrupt handler for this should only be used if not using auto vectored interrupts with int4
+ IE4_ISR, ///< External interrupt 4.  An interrupt handler for this should only be used if not using auto vectored interrupts with INT4
  IE5_ISR, ///< External interrupt 5
  IE6_ISR, ///< External interrupt 6
  // Better names for the USART ISR names

--- a/include/fx2regs.h
+++ b/include/fx2regs.h
@@ -635,4 +635,10 @@ __sfr __at 0xF8 EIP; // EIP Bit Values differ from Reg320
 #define bmEP1OUTBSY     bmBIT1
 #define bmEP0BSY        bmBIT0
 
+/* EXIF - External interrupt flags */
+#define bmIE5           bmBIT7
+#define bmIE4           bmBIT6
+#define bmI2CINT        bmBIT5
+#define bmUSBNT         bmBIT4
+
 #endif   /* FX2REGS_H */


### PR DESCRIPTION
Adding code and documentation for using the hardware USART and I2C controller as interrupt driven peripherals rather than polling.

**This is a work in progress.** Still need to publish some simple examples showing how to properly use this functionality.