### PR TITLE
Clean up of setupdat{.h,.c} files.

### DIFF
--- a/include/setupdat.h
+++ b/include/setupdat.h
@@ -217,6 +217,11 @@ void handle_setupdata();
  **/
 void handle_hispeed( BOOL highspeed );
 
+/* Descriptor header */
+typedef struct {
+    BYTE dsc_len;
+    BYTE dsc_type;
+} HEADER_DSCR;
 
 /* descriptor types */
 #define DSCR_DEVICE_TYPE 1
@@ -226,13 +231,10 @@ void handle_hispeed( BOOL highspeed );
 #define DSCR_OTHERSPD_TYPE 7
 #define DSCR_DEBUG_TYPE 10
 
-/* usb spec 2 */
-#define DSCR_BCD 2
+/* USB version 2.0 */
+#define DSCR_BCD 0x0200
 
-
-/* device descriptor */
-#define DSCR_DEVICE_LEN 18
-
+/* Device descriptor */
 typedef struct {
     BYTE dsc_len; // descriptor length (18 for this )
     BYTE dsc_type; // dscr type
@@ -248,26 +250,18 @@ typedef struct {
     BYTE idx_devstr; // product string index
     BYTE idx_serstr; // serial number index
     BYTE num_configs; // number of configurations
-        
 } DEVICE_DSCR;
+#define DSCR_DEVICE_LEN 18
 
-
-/* config descriptor */
+/* Config descriptor  */
 #define DSCR_CONFIG_LEN 9
-typedef struct {
-    BYTE dsc_len; // 9 for this one
-    BYTE dsc_type; // dscr type
-    
-} CONFIG_DSCR;
+#define CONFIG_DSCR DSCR_HEAD
 
-/* string descriptor */
+/* String descriptor */
 typedef struct {
     BYTE dsc_len;
     BYTE dsc_type;
     BYTE pstr;
 } STRING_DSCR;
-
-
-
 
 #endif

--- a/include/setupdat.h
+++ b/include/setupdat.h
@@ -138,34 +138,83 @@ typedef enum {
 
 
 /**
- * returns the control/status register for an end point
- * (bit 7=1 for IN, 0 for out
+ * \brief Get pointer to an endpoint's control/status register.
+ *
+ * \param Endpoint number (lower bits) and direction (bit 7).
  **/
 __xdata BYTE* ep_addr(BYTE ep);
 
 /*
- You can call this function directly if you are polling
- for setup data in your main loop.
- You can also use the usbjt and enable the sudav isr
- and call the function from withing the sudav isr routine
-*/
+ * \brief Handle the "setup data" USB requests.
+ *
+ * This function should *not* be called inside an ISR (as it calls
+ * non-reentrant functions). Instead you should set a flag inside the ISR and
+ * then call this function ASAP as part of your main loop.
+ *
+ * \code
+ * volatile __bit dosud=FALSE;
+ * void sudav_isr() __interrupt SUDAV_ISR {
+ *     CLEAR_SUDAV();
+ *     if(dosud) {
+ *         // Indicate error
+ *     }
+ *     dosud=TRUE;
+ * }
+ *
+ * void main() {
+ *     // Other init code
+ *     ENABLE_SUDAV();
+ *     EA=1; // Enable interrupts
+ *
+ *     while(TRUE) {
+ *         if(dosud) { // Check flag
+ *             handle_setupdata();
+ *             dosud=FALSE;
+ *         }
+ *         // Other loop code
+ *     }
+ * }
+ * \endcode
+ */
 void handle_setupdata();
 
 
 /**
-    For devices to properly handle usb hispeed
-    (This is if your descriptor has high speed and full speed versions
-     and it should since the fx2lp is a high speed capable device
-    )
-    enable both USBRESET and HISPEED interrupts and
-    call this function to switch the descriptors.  This function uses
-    a __critical section to switch the descriptors and is safe to call
-    from the hispeed or reset interrupt.  See \ref fw.c
-
-    \param highspeed Call the function with highspeed = TRUE if 
-        calling because the highspeed interrupt was received.
-        If calling from usbreset, call with highspeed=false
-**/
+ * \brief Switch the descriptor pointer to right descriptor version.
+ *
+ * This function switches the descriptor pointer between the high speed and
+ * full speed descriptor versions. To use this function;
+ *  \li Your descriptors should have both versions.
+ *  \li Enable both USBRESET and HISPEED interrupts.
+ *  \li In your ISR for these functions call this method;
+ *    \li  * highspeed = FALSE for USBRESET
+ *    \li  * highspeed = TRUE for HISPEED
+ *
+ * This function is safe to call both inside an ISR and outside because it
+ * disable interrupts while operating (__critical).
+ *
+ * \code
+ * void usbreset_isr() __interrupt USBRESET_ISR {
+ *     handle_hispeed(FALSE);
+ *     CLEAR_USBRESET();
+ * }
+ * void hispeed_isr() __interrupt HISPEED_ISR {
+ *     handle_hispeed(TRUE);
+ *     CLEAR_HISPEED();
+ * }
+ *
+ * void main() {
+ *     ENABLE_USBRESET();
+ *     ENABLE_HISPEED();
+ * }
+ * \endcode
+ *
+ * See \ref fw.c for full example.
+ *
+ * \param highspeed Use high speed descriptor?
+ *     \li TRUE, use high speed descriptor.
+ *     \li FALSE, use full speed descriptor.
+ **/
 void handle_hispeed( BOOL highspeed );
 
 

--- a/lib/setupdat.c
+++ b/lib/setupdat.c
@@ -131,9 +131,6 @@ void handle_setupdata() {
     EP0CS |= bmHSNAK;
 }
 
-/**
- * \brief Get pointer to an endpoint's control status register.
- **/
 __xdata BYTE* ep_addr(BYTE ep) {
     // Bit 8 of ep_num is the direction (In or Out) of the endpoint.
     BYTE ep_num = ep & ~bmBIT7;
@@ -297,10 +294,9 @@ WORD pDevConfig = (WORD)&fullspd_dscr;
 WORD pOtherConfig = (WORD)&highspd_dscr;
 
 /**
- * \brief Change descriptor pointer to either high speed or full speed descriptors.
- *
  * This function is called inside ISR functions, so must *not* call any
- * non-reentrant functions. (This includes things like printf provided by sdcc.)
+ * non-reentrant functions.
+ * (This *includes* things like printf provided by SDCC.)
  **/
 void handle_hispeed(BOOL highspeed) __critical {
     if (highspeed) {

--- a/lib/setupdat.c
+++ b/lib/setupdat.c
@@ -40,7 +40,7 @@ extern BYTE handle_get_configuration();
 extern void handle_reset_ep(BYTE ep);
 
 /**
- * Predefs for handlers
+ * Forward declaration for handlers
  **/
 
 
@@ -52,7 +52,7 @@ BOOL handle_clear_feature();
 //  SET_FEATURE=0x03,
 BOOL handle_set_feature();
   // 0x04 is reserved
-//  SET_ADDRESS=0x05, // this is handled by EZ-USB core unless RENUM=0
+//  SET_ADDRESS=0x05, // SET_ADDRESS is *always* handled by EZ-USB core.
 //  GET_DESCRIPTOR,
 void _handle_get_descriptor();
 //  SET_DESCRIPTOR,
@@ -274,7 +274,7 @@ BOOL handle_set_feature() {
  return TRUE;
 }
 
-/* these are devined in dscr.asm
+/* these are defined in dscr.asm
    and need to be customized then
    linked in by the firmware manually */
 extern __code WORD dev_dscr;

--- a/lib/setupdat.c
+++ b/lib/setupdat.c
@@ -286,9 +286,14 @@ extern __code WORD dev_strings;
 WORD pDevConfig = (WORD)&fullspd_dscr;
 WORD pOtherConfig = (WORD)&highspd_dscr;
 
+/**
+ * \brief Change descriptor pointer to either high speed or full speed descriptors.
+ *
+ * This function is called inside ISR functions, so must *not* call any
+ * non-reentrant functions. (This includes things like printf provided by sdcc.)
+ **/
 void handle_hispeed(BOOL highspeed) {
  __critical { 
-     printf ( "Hi Speed or reset Interrupt\n" );
      if (highspeed) {
          pDevConfig=(WORD)&highspd_dscr;
          pOtherConfig=(WORD)&fullspd_dscr;

--- a/lib/setupdat.c
+++ b/lib/setupdat.c
@@ -73,7 +73,6 @@ void handle_setupdata() {
     //printf ( "Handle setupdat: %02x\n", SETUPDAT[1] );
 
     switch ( SETUPDAT[1] ) {
-
         case GET_STATUS:
             if (!handle_get_status())
                 STALLEP0();
@@ -109,9 +108,9 @@ void handle_setupdata() {
                 if (!handle_get_interface(SETUPDAT[4],&alt_ifc)) {
                     STALLEP0();
                 } else {
-                 EP0BUF[0] = alt_ifc;
-                 EP0BCH=0;
-                 EP0BCL=1;
+                    EP0BUF[0] = alt_ifc;
+                    EP0BCH=0;
+                    EP0BCL=1;
                 }
             }
             break;
@@ -122,17 +121,14 @@ void handle_setupdata() {
             }
             break;
         default:
-         if (!handle_vendorcommand(SETUPDAT[1])) {
-            printf ( "Unhandled Vendor Command: %02x\n" , SETUPDAT[1] );
-            STALLEP0();
-         }
-        
-        
+            if (!handle_vendorcommand(SETUPDAT[1])) {
+                printf ( "Unhandled Vendor Command: %02x\n" , SETUPDAT[1] );
+                STALLEP0();
+            }
     }
     
     // do the handshake
     EP0CS |= bmHSNAK;
-    
 }
 
 /**

--- a/lib/setupdat.c
+++ b/lib/setupdat.c
@@ -283,7 +283,13 @@ extern __code WORD highspd_dscr;
 extern __code WORD fullspd_dscr;
 extern __code WORD dev_strings;
 
+/**
+ * \brief Pointer to the active descriptor.
+ **/
 WORD pDevConfig = (WORD)&fullspd_dscr;
+/**
+ * \brief Pointer to the inactive descriptor.
+ **/
 WORD pOtherConfig = (WORD)&highspd_dscr;
 
 /**

--- a/lib/setupdat.c
+++ b/lib/setupdat.c
@@ -292,16 +292,14 @@ WORD pOtherConfig = (WORD)&highspd_dscr;
  * This function is called inside ISR functions, so must *not* call any
  * non-reentrant functions. (This includes things like printf provided by sdcc.)
  **/
-void handle_hispeed(BOOL highspeed) {
- __critical { 
-     if (highspeed) {
-         pDevConfig=(WORD)&highspd_dscr;
-         pOtherConfig=(WORD)&fullspd_dscr;
-     } else {
+void handle_hispeed(BOOL highspeed) __critical {
+    if (highspeed) {
+        pDevConfig=(WORD)&highspd_dscr;
+        pOtherConfig=(WORD)&fullspd_dscr;
+    } else {
         pDevConfig=(WORD)&fullspd_dscr;
         pOtherConfig=(WORD)&highspd_dscr;
-     }
- }
+    }
 }
 
 /**

--- a/lib/setupdat.c
+++ b/lib/setupdat.c
@@ -135,17 +135,21 @@ void handle_setupdata() {
     
 }
 
-__xdata BYTE* ep_addr(BYTE ep) { // bit 8 of ep_num is the direction
- BYTE ep_num = ep&~0x80; // mask the direction
- switch (ep_num) {
-  case 0: return &EP0CS;
-  case 1: return ep&0x80? &EP1INCS : &EP1OUTCS;
-  case 2: return &EP2CS;
-  case 4: return &EP4CS;
-  case 6: return &EP6CS;
-  case 8: return &EP8CS;
-  default: return NULL;
- }
+/**
+ * \brief Get pointer to an endpoint's control status register.
+ **/
+__xdata BYTE* ep_addr(BYTE ep) {
+    // Bit 8 of ep_num is the direction (In or Out) of the endpoint.
+    BYTE ep_num = ep & ~bmBIT7;
+    switch (ep_num) {
+        case 0: return &EP0CS;
+        case 1: return (ep&0x80) ? &EP1INCS : &EP1OUTCS;
+        case 2: return &EP2CS;
+        case 4: return &EP4CS;
+        case 6: return &EP6CS;
+        case 8: return &EP8CS;
+        default: return NULL;
+    }
 }
 
 

--- a/lib/setupdat.c
+++ b/lib/setupdat.c
@@ -35,7 +35,7 @@ extern BOOL handle_get_descriptor();
 extern BOOL handle_vendorcommand(BYTE cmd);
 extern BOOL handle_set_configuration(BYTE cfg);
 extern BOOL handle_get_interface(BYTE ifc, BYTE* alt_ifc);
-extern BOOL handle_set_interface(BYTE ifc,BYTE alt_ifc);
+extern BOOL handle_set_interface(BYTE ifc, BYTE alt_ifc);
 extern BYTE handle_get_configuration();
 extern void handle_reset_ep(BYTE ep);
 
@@ -99,7 +99,7 @@ void handle_setupdata() {
             break;
         case SET_CONFIGURATION:
             // user callback
-            if( !handle_set_configuration(SETUPDAT[2])) {
+            if(!handle_set_configuration(SETUPDAT[2])) {
                 STALLEP0();
             }
             break;
@@ -117,7 +117,7 @@ void handle_setupdata() {
             break;
         case SET_INTERFACE:
             // user callback
-            if ( !handle_set_interface(SETUPDAT[4],SETUPDAT[2])) {
+            if (!handle_set_interface(SETUPDAT[4],SETUPDAT[2])) {
                 STALLEP0();
             }
             break;

--- a/lib/setupdat.c
+++ b/lib/setupdat.c
@@ -70,7 +70,7 @@ void _handle_get_descriptor();
 */
 
 void handle_setupdata() {
-    //printf ( "Handle setupdat: %02x\n", SETUPDAT[1] );
+    printf("Handle setupdat: 0x%02x\n", SETUPDAT[1]);
 
     switch ( SETUPDAT[1] ) {
         case GET_STATUS:
@@ -122,7 +122,7 @@ void handle_setupdata() {
             break;
         default:
             if (!handle_vendorcommand(SETUPDAT[1])) {
-                printf ( "Unhandled Vendor Command: %02x\n" , SETUPDAT[1] );
+                printf("Unhandled Vendor Command: 0x%02x\n" , SETUPDAT[1]);
                 STALLEP0();
             }
     }
@@ -161,8 +161,8 @@ volatile BOOL remote_wakeup_allowed=FALSE;
 BOOL handle_get_status() {
     
     switch ( SETUPDAT[0] ) {
-
 //        case 0: // sometimes we get a 0 status too
+
         case GS_INTERFACE: 
             EP0BUF[0] = 0;
             EP0BUF[1] = 0;
@@ -191,10 +191,8 @@ BOOL handle_get_status() {
             }
             break;
         default:
-            printf ( "Unexpected Get Status: %02x\n", SETUPDAT[0] );
+            printf("Unexpected Get Status: 0x%02x\n", SETUPDAT[0]);
             return FALSE;
-            
-                        
     }
     return TRUE;
 }
@@ -204,7 +202,8 @@ BOOL handle_get_status() {
 #define GF_ENDPOINT 2
 
 BOOL handle_clear_feature() {
-    printf ( "Clear Feature %02x\n", SETUPDAT[0] );
+    printf("Clear Feature 0x%02x\n", SETUPDAT[0]);
+
     switch ( SETUPDAT[0] ) {
         case GF_DEVICE:
             if (SETUPDAT[2] == 1) {
@@ -219,11 +218,11 @@ BOOL handle_clear_feature() {
         case GF_ENDPOINT:
             if (SETUPDAT[2] == 0) { // ep stall feature
                 __xdata BYTE* pep=ep_addr(SETUPDAT[4]);
-                printf ( "unstall endpoint %02X\n" , SETUPDAT[4] );
+                printf("unstall endpoint 0x%02x\n" , SETUPDAT[4]);
                 *pep &= ~bmEPSTALL;
                 RESETTOGGLE(SETUPDAT[4]);
             } else {
-                printf ( "unsupported ep feature %02x", SETUPDAT[2] );
+                printf("unsupported ep feature 0x%02x\n", SETUPDAT[2]);
                 return FALSE;
             }
             break;
@@ -234,7 +233,8 @@ BOOL handle_clear_feature() {
 }
 
 BOOL handle_set_feature() {
-    printf ( "Set Feature %02x\n", SETUPDAT[0] );
+    printf("Set Feature 0x%02x\n", SETUPDAT[0]);
+
     switch ( SETUPDAT[0] ) {
         case GF_DEVICE:
             // this is TEST_MODE and we simply need to return the handshake
@@ -255,7 +255,7 @@ BOOL handle_set_feature() {
                 // set TRM 2.3.2
                 // stall and endpoint
                 __xdata BYTE* pep = ep_addr(SETUPDAT[4]);
-                printf ( "Stall ep %d\n", SETUPDAT[4] );
+                printf("Stall ep 0x%02x\n", SETUPDAT[4]);
                 if (!pep) {
                     return FALSE;
                 }
@@ -268,7 +268,7 @@ BOOL handle_set_feature() {
                 // NOTE
                 //handle_reset_ep(SETUPDAT[4]);
             } else {
-                printf ( "unsupported ep feature %02x\n", SETUPDAT[2] );
+                printf("unsupported ep feature 0x%02x\n", SETUPDAT[2]);
                 return FALSE;
             }
             break;
@@ -321,22 +321,22 @@ void handle_hispeed(BOOL highspeed) __critical {
  *  Other-Speed
  **/
 void _handle_get_descriptor() {
-    //printf ( "Get Descriptor\n" );
-    
+    printf("Get Descriptor ");
+
     switch ( SETUPDAT[3] ) {
         case DSCR_DEVICE_TYPE:
-            printf ( "Get Device Config\n" );
+            printf("Device\n");
             SUDPTRH = MSB((WORD)&dev_dscr);
             SUDPTRL = LSB((WORD)&dev_dscr);
             break;
         case DSCR_CONFIG_TYPE:
             // get the config descriptor
-            printf ( "Get Config Descriptor\n");
+            printf("Config\n");
             SUDPTRH = MSB(pDevConfig);
             SUDPTRL = LSB(pDevConfig);
             break;        
         case DSCR_STRING_TYPE:
-            //printf ( "Get String Descriptor idx: %d\n", SETUPDAT[2] );
+            printf("String idx: %d\n", SETUPDAT[2]);
             {
                 STRING_DSCR* pStr = (STRING_DSCR*)&dev_strings;
                 // pStr points to string 0
@@ -344,20 +344,20 @@ void _handle_get_descriptor() {
                 BYTE cur=0; // current check
                 do {
                     if (idx==cur++) break;
-                    //printf ( "Length of pStr: %d\n", pStr->dsc_len );
-                    //printf ( "pstr: %04x to ", pStr );
+                    //printf("Length of pStr: %d\n", pStr->dsc_len);
+                    //printf("pstr: 0x%04x to ", pStr);
                     pStr = (STRING_DSCR*)((BYTE*)pStr + pStr->dsc_len);
-                    //printf ( "%04x\n" , pStr );
+                    //printf("%04x\n", pStr);
                     if (pStr->dsc_type != DSCR_STRING_TYPE) pStr=NULL;
                 } while ( pStr && cur<=idx);
                 
                 if (pStr) {
-                    /* BYTE i;
-                    //printf ( "found str: '");
-                    for (i=0;i<pStr->dsc_len-2;++i) {
-                       printf ( i%2==0?"%c":"%02x", *((BYTE*)(&pStr->pstr)+i));
-                    } printf ( "\n"); */
-                    
+                    //BYTE i;
+                    //printf("found str: '");
+                    //for (i=0;i<pStr->dsc_len-2;++i) {
+                    //    printf(i%2==0?"%c":"%02x", *((BYTE*)(&pStr->pstr)+i));
+                    //} printf("\n");
+
                     SUDPTRH = MSB((WORD)pStr);
                     SUDPTRL = LSB((WORD)pStr);
                     //SUDPTRH = MSB((WORD)&dev_strings);
@@ -368,20 +368,18 @@ void _handle_get_descriptor() {
             
             break;
         case DSCR_DEVQUAL_TYPE:
-            printf ( "Get Device Qualifier Descriptor\n");
+            printf("Device Qualifier\n");
             // assumes this is a high speed capable device
             SUDPTRH = MSB((WORD)&dev_qual_dscr);
             SUDPTRL = LSB((WORD)&dev_qual_dscr);
             break;
         case DSCR_OTHERSPD_TYPE:
-            printf ( "Other Speed Descriptor\n");
+            printf("Other Speed\n");
             SUDPTRH = MSB(pOtherConfig);
             SUDPTRL = LSB(pOtherConfig);
             break;
         default:
-            printf ( "Unhandled Get Descriptor: %02x\n", SETUPDAT[3]);
+            printf("Unknown: %02x\n", SETUPDAT[3]);
             STALLEP0();
     }
-    
 }
-


### PR DESCRIPTION
This pull request should contain no functionality changes but cleans up the setupdat related files (mostly formatting and documentation).

This changes the documentation around the `handle_setupdata` function as it **can't** reliably be called from inside ISRs without a bunch of changes;
 * Compiling your SDCC with reentrant enabled printf functions (and possibly others).
 * Linking against the reentrant / nooverlay versions of the 16bit integer support functions.
 * And, either;
   * Compiling with `nooverlay` enabled
   * Using pragma's to disable overlaying like follows;
```c
#pragma save
#pragma nooverlay
void set_error(unsigned char errcd)
{
P3 = errcd;
}
#pragma restore
```

All these properties need to hold for the user functions which setupdat calls too.