### PR TITLE
Allow redefining SDCC commands in Makefile

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -15,16 +15,18 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 AS8051?=sdas8051
+CC=sdcc
+CCLIB?=sdcclib
 SOURCES = serial.c i2c.c delay.c setupdat.c gpif.c eputils.c $(wildcard interrupts/*.c)
 FX2_OBJS = $(patsubst %.c,%.rel, $(SOURCES)) usbav.rel
 INCLUDES = -I../include
-SDCC = sdcc -mmcs51 $(SDCCFLAGS)
+SDCC = $(CC) -mmcs51 $(SDCCFLAGS)
 LIBS = fx2.lib
 
 all: $(LIBS)
 
 $(LIBS): $(FX2_OBJS)
-	sdcclib fx2.lib $?
+	$(CCLIB) fx2.lib $?
 
 usbav.rel: usbav.a51
 	$(AS8051) -logs usbav.a51

--- a/lib/fx2.mk
+++ b/lib/fx2.mk
@@ -43,6 +43,7 @@ PID?=0x8613
 INCLUDES?=""
 DSCR_AREA?=-Wl"-b DSCR_AREA=0x3e00"
 INT2JT?=-Wl"-b INT2JT=0x3f00"
+CC=sdcc
 CODE_SIZE?=--code-size 0x3c00
 XRAM_SIZE?=--xram-size 0x0200
 XRAM_LOC?=--xram-loc 0x3c00
@@ -54,7 +55,7 @@ RELS=$(addprefix $(BUILDDIR)/, $(addsuffix .rel, $(notdir $(basename $(SOURCES) 
 # these are pretty good settings for most firmwares.  
 # Have to be careful with memory locations for 
 # firmwares that require more xram etc.
-CC = sdcc -mmcs51 \
+SDCC = $(CC) -mmcs51 \
 	$(SDCCFLAGS) \
     $(CODE_SIZE) \
     $(XRAM_SIZE) \
@@ -84,8 +85,8 @@ $(BUILDDIR)/$(BASENAME).ihx: $(BUILDDIR) $(SOURCES) $(A51_SOURCES) $(FX2LIBDIR)/
 	 cd $(BUILDDIR) && $(AS8051) -logs `basename $$a` && cd ..; done
 	for s in $(SOURCES); do \
 	 THISREL=$$(basename `echo "$$s" | sed -e 's/\.c$$/\.rel/'`); \
-	 $(CC) -c -I $(FX2LIBDIR)/include -I $(INCLUDES) $$s -o $(BUILDDIR)/$$THISREL ; done
-	$(CC) -o $@ $(RELS) fx2.lib -L $(FX2LIBDIR)/lib $(LIBS)
+	 $(SDCC) -c -I $(FX2LIBDIR)/include -I $(INCLUDES) $$s -o $(BUILDDIR)/$$THISREL ; done
+	$(SDCC) -o $@ $(RELS) fx2.lib -L $(FX2LIBDIR)/lib $(LIBS)
 
 
 $(BUILDDIR)/$(BASENAME).bix: $(BUILDDIR)/$(BASENAME).ihx


### PR DESCRIPTION
Some GNU/Linux distributions come with SDCC packaged with a prefix, so it should be invoked as `sdcc-sdcc` and `sdcc-sdcclib`, for instance. This change allows to build the library in such environments.

`CC` is assigned unconditionally because GNU Make provides a built-in value `cc`. It can still be reassigned via an argument:

```
make CC=sdcc-sdcc CCLIB=sdcc-sdcclib AS8051=sdcc-sdas8051
```