### PR TITLE
make comportable with SDCC 3.9.0 (sdcclib was replaced with sdar utility)

### DIFF
--- a/include/serial.h
+++ b/include/serial.h
@@ -51,5 +51,5 @@ void sio0_init( DWORD baud_rate ) __critical ; // baud_rate max should be 57600 
  putchar('\\n') or putchar('\\r') both transmit \\r\\n
  Just use one or the other. (This makes terminal echo easy)
 **/
-void putchar(char c);
-char getchar();
+int putchar(char c);
+int getchar();

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -16,7 +16,7 @@
 
 AS8051?=sdas8051
 CC=sdcc
-CCLIB?=sdcclib
+SDAR?=sdar
 SOURCES = serial.c i2c.c delay.c setupdat.c gpif.c eputils.c $(wildcard interrupts/*.c)
 FX2_OBJS = $(patsubst %.c,%.rel, $(SOURCES)) usbav.rel
 INCLUDES = -I../include
@@ -26,7 +26,7 @@ LIBS = fx2.lib
 all: $(LIBS)
 
 $(LIBS): $(FX2_OBJS)
-	$(CCLIB) fx2.lib $?
+	$(SDAR) -rc fx2.lib $?
 
 usbav.rel: usbav.a51
 	$(AS8051) -logs usbav.a51


### PR DESCRIPTION
Just realized that in the latest SDCC 3.9.0 sdcclib was removed as deprecated and there is sdar as replacement. I just updated the Makefile + fixed issue with putchar/getchar signatures.